### PR TITLE
new feature/option: toggleable js/css-files aggregation

### DIFF
--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -57,6 +57,7 @@ class autoptimizeConfig
 
     public function show()
     {
+        $conf = self::instance();
 ?>
 <style>
 /* title and button */
@@ -231,6 +232,16 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <td><input type="checkbox" id="autoptimize_js" name="autoptimize_js" <?php echo get_option('autoptimize_js')?'checked="checked" ':''; ?>/></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
+<th scope="row"><?php _e( 'Aggregate JS-files?', 'autoptimize' ); ?></th>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_aggregate" <?php echo $conf->get( 'autoptimize_js_aggregate' ) ? 'checked="checked" ':''; ?>/>
+<?php _e( 'Aggregate all linked JS-files to have them loaded non-render blocking? If this option is off, the individual JS-files will remain in place but will be minified.', 'autoptimize' ); ?></label></td>
+</tr>
+<tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
+<th scope="row"><?php _e('Also aggregate inline JS?','autoptimize'); ?></th>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_include_inline" <?php echo get_option('autoptimize_js_include_inline')?'checked="checked" ':''; ?>/>
+<?php _e('Let Autoptimize also extract JS from the HTML. <strong>Warning</strong>: this can make Autoptimize\'s cache size grow quickly, so only enable this if you know what you\'re doing.','autoptimize'); ?></label></td>
+</tr>
+<tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
 <th scope="row"><?php _e('Force JavaScript in &lt;head&gt;?','autoptimize'); ?></th>
 <td><label class="cb_label"><input type="checkbox" name="autoptimize_js_forcehead" <?php echo get_option('autoptimize_js_forcehead')?'checked="checked" ':''; ?>/>
 <?php _e('Load JavaScript early, this can potentially fix some JS-errors, but makes the JS render blocking.','autoptimize'); ?></label></td>
@@ -242,11 +253,6 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <?php _e('Mostly useful in combination with previous option when using jQuery-based templates, but might help keeping cache size under control.','autoptimize'); ?></label></td>
 </tr>
 <?php } ?>
-<tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
-<th scope="row"><?php _e('Also aggregate inline JS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_include_inline" <?php echo get_option('autoptimize_js_include_inline')?'checked="checked" ':''; ?>/>
-<?php _e('Let Autoptimize also extract JS from the HTML. <strong>Warning</strong>: this can make Autoptimize\'s cache size grow quickly, so only enable this if you know what you\'re doing.','autoptimize'); ?></label></td>
-</tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
 <th scope="row"><?php _e('Exclude scripts from Autoptimize:','autoptimize'); ?></th>
 <td><label><input type="text" style="width:100%;" name="autoptimize_js_exclude" value="<?php echo get_option('autoptimize_js_exclude',"seal.js, js/jquery/jquery.js"); ?>"/><br />
@@ -268,6 +274,16 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <td><input type="checkbox" id="autoptimize_css" name="autoptimize_css" <?php echo get_option('autoptimize_css')?'checked="checked" ':''; ?>/></td>
 </tr>
 <tr class="<?php echo $hiddenClass;?>css_sub ao_adv" valign="top">
+<th scope="row"><?php _e( 'Aggregate CSS-files?', 'autoptimize' ); ?></th>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_aggregate" <?php echo $conf->get( 'autoptimize_css_aggregate' ) ? 'checked="checked" ' : ''; ?>/>
+<?php _e('Aggregate all linked CSS-files? If this option is off, the individual CSS-files will remain in place but will be minified.', 'autoptimize' ); ?></label></td>
+</tr>
+<tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv">
+<th scope="row"><?php _e('Also aggregate inline CSS?','autoptimize'); ?></th>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_include_inline" <?php echo get_option('autoptimize_css_include_inline','1')?'checked="checked" ':''; ?>/>
+<?php _e('Check this option for Autoptimize to also aggregate CSS in the HTML.','autoptimize'); ?></label></td>
+</tr>
+<tr class="<?php echo $hiddenClass;?>css_sub ao_adv" valign="top">
 <th scope="row"><?php _e('Generate data: URIs for images?','autoptimize'); ?></th>
 <td><label class="cb_label"><input type="checkbox" name="autoptimize_css_datauris" <?php echo get_option('autoptimize_css_datauris')?'checked="checked" ':''; ?>/>
 <?php _e('Enable this to include small background-images in the CSS itself instead of as separate downloads.','autoptimize'); ?></label></td>
@@ -279,11 +295,6 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <?php _e('Don\'t autoptimize CSS outside the head-section. If the cache gets big, you might want to enable this.','autoptimize'); ?></label></td>
 </tr>
 <?php } ?>
-<tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv">
-<th scope="row"><?php _e('Also aggregate inline CSS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_include_inline" <?php echo get_option('autoptimize_css_include_inline','1')?'checked="checked" ':''; ?>/>
-<?php _e('Check this option for Autoptimize to also aggregate CSS in the HTML.','autoptimize'); ?></label></td>
-</tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv">
 <th scope="row"><?php _e('Inline and Defer CSS?','autoptimize'); ?></th>
 <td><label class="cb_label"><input type="checkbox" name="autoptimize_css_defer" id="autoptimize_css_defer" <?php echo get_option('autoptimize_css_defer')?'checked="checked" ':''; ?>/>
@@ -587,12 +598,14 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
         register_setting( 'autoptimize', 'autoptimize_html' );
         register_setting( 'autoptimize', 'autoptimize_html_keepcomments' );
         register_setting( 'autoptimize', 'autoptimize_js' );
+        register_setting( 'autoptimize', 'autoptimize_js_aggregate' );
         register_setting( 'autoptimize', 'autoptimize_js_exclude' );
         register_setting( 'autoptimize', 'autoptimize_js_trycatch' );
         register_setting( 'autoptimize', 'autoptimize_js_justhead' );
         register_setting( 'autoptimize', 'autoptimize_js_forcehead' );
         register_setting( 'autoptimize', 'autoptimize_js_include_inline' );
         register_setting( 'autoptimize', 'autoptimize_css' );
+        register_setting( 'autoptimize', 'autoptimize_css_aggregate' );
         register_setting( 'autoptimize', 'autoptimize_css_exclude' );
         register_setting( 'autoptimize', 'autoptimize_css_justhead' );
         register_setting( 'autoptimize', 'autoptimize_css_datauris' );
@@ -642,12 +655,14 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
             'autoptimize_html' => 0,
             'autoptimize_html_keepcomments' => 0,
             'autoptimize_js' => 0,
+            'autoptimize_js_aggregate' => 1,
             'autoptimize_js_exclude' => 'seal.js, js/jquery/jquery.js',
             'autoptimize_js_trycatch' => 0,
             'autoptimize_js_justhead' => 0,
             'autoptimize_js_include_inline' => 0,
             'autoptimize_js_forcehead' => 0,
             'autoptimize_css' => 0,
+            'autoptimize_css_aggregate' => 1,
             'autoptimize_css_exclude' => 'admin-bar.min.css, dashicons.min.css, wp-content/cache/, wp-content/uploads/',
             'autoptimize_css_justhead' => 0,
             'autoptimize_css_include_inline' => 1,

--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -390,7 +390,7 @@ class autoptimizeMain
                 'include_inline' => $conf->get( 'autoptimize_js_include_inline' ),
             ),
             'autoptimizeStyles'  => array(
-                'aggregate'      => $conf->get( 'autoptimize_js_aggregate' ),
+                'aggregate'      => $conf->get( 'autoptimize_css_aggregate' ),
                 'justhead'       => $conf->get( 'autoptimize_css_justhead' ),
                 'datauris'       => $conf->get( 'autoptimize_css_datauris' ),
                 'defer'          => $conf->get( 'autoptimize_css_defer' ),

--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -381,6 +381,7 @@ class autoptimizeMain
 
         $classoptions = array(
             'autoptimizeScripts' => array(
+                'aggregate'      => $conf->get( 'autoptimize_js_aggregate' ),
                 'justhead'       => $conf->get( 'autoptimize_js_justhead' ),
                 'forcehead'      => $conf->get( 'autoptimize_js_forcehead' ),
                 'trycatch'       => $conf->get( 'autoptimize_js_trycatch' ),
@@ -389,6 +390,7 @@ class autoptimizeMain
                 'include_inline' => $conf->get( 'autoptimize_js_include_inline' ),
             ),
             'autoptimizeStyles'  => array(
+                'aggregate'      => $conf->get( 'autoptimize_js_aggregate' ),
                 'justhead'       => $conf->get( 'autoptimize_css_justhead' ),
                 'datauris'       => $conf->get( 'autoptimize_css_datauris' ),
                 'defer'          => $conf->get( 'autoptimize_css_defer' ),

--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -27,6 +27,7 @@ class autoptimizeScripts extends autoptimizeBase
         'jd.gallery.js.php','jd.gallery.transitions.js','swfobject.embedSWF(','linkwithin.com/widget.js','tiny_mce.js','tinyMCEPreInit.go'
     );
 
+    private $aggregate       = true;
     private $trycatch        = false;
     private $alreadyminified = false;
     private $forcehead       = true;
@@ -64,6 +65,15 @@ class autoptimizeScripts extends autoptimizeBase
             $content             = explode( '</head>', $this->content, 2 );
             $this->content       = $content[0] . '</head>';
             $this->restofcontent = $content[1];
+        }
+
+        // Determine whether we're doing JS-files aggregation or not.
+        if ( ! $options['aggregate'] ) {
+            $this->aggregate = false;
+        }
+        // Returning true for "dontaggregate" turns off aggregation.
+        if ( $this->aggregate && apply_filters( 'autoptimize_filter_js_dontaggregate', false ) ) {
+            $this->aggregate = false;
         }
 
         // include inline?
@@ -410,7 +420,7 @@ class autoptimizeScripts extends autoptimizeBase
     // Checks against the white- and blacklists
     private function ismergeable($tag)
     {
-        if ( apply_filters( 'autoptimize_filter_js_dontaggregate', false ) ) {
+        if ( ! $this->aggregate ) {
             return false;
         }
 
@@ -512,4 +522,13 @@ class autoptimizeScripts extends autoptimizeBase
         }
     }
 
+    /**
+     * Returns whether we're doing aggregation or not.
+     *
+     * @return bool
+     */
+    public function aggregating()
+    {
+        return $this->aggregate;
+    }
 }

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -913,7 +913,9 @@ class autoptimizeStyles extends autoptimizeBase
     {
         if ( ! $this->aggregate ) {
             return false;
-        } else if ( ! empty( $this->whitelist ) ) {
+        }
+
+        if ( ! empty( $this->whitelist ) ) {
             foreach ( $this->whitelist as $match ) {
                 if ( false !== strpos( $tag, $match ) ) {
                     return true;

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -32,6 +32,7 @@ class autoptimizeStyles extends autoptimizeBase
     private $datauris        = false;
     private $hashmap         = array();
     private $alreadyminified = false;
+    private $aggregate       = true;
     private $inline          = false;
     private $defer           = false;
     private $defer_inline    = false;
@@ -69,6 +70,15 @@ class autoptimizeStyles extends autoptimizeBase
             $content             = explode( '</head>', $this->content, 2 );
             $this->content       = $content[0] . '</head>';
             $this->restofcontent = $content[1];
+        }
+
+        // Determine whether we're doing CSS-files aggregation or not.
+        if ( isset( $options['aggregate'] ) && ! $options['aggregate'] ) {
+            $this->aggregate = false;
+        }
+        // Returning true for "dontaggregate" turns off aggregation.
+        if ( $this->aggregate && apply_filters( 'autoptimize_filter_css_dontaggregate', false ) ) {
+            $this->aggregate = false;
         }
 
         // include inline?
@@ -901,7 +911,7 @@ class autoptimizeStyles extends autoptimizeBase
 
     private function ismovable($tag)
     {
-        if ( apply_filters( 'autoptimize_filter_css_dontaggregate', false ) ) {
+        if ( ! $this->aggregate ) {
             return false;
         } else if ( ! empty( $this->whitelist ) ) {
             foreach ( $this->whitelist as $match ) {
@@ -948,6 +958,16 @@ class autoptimizeStyles extends autoptimizeBase
             // phew, all is safe, we can late-inject
             return true;
         }
+    }
+
+    /**
+     * Returns whether we're doing aggregation or not.
+     *
+     * @return bool
+     */
+    public function aggregating()
+    {
+        return $this->aggregate;
     }
 
     public function getOptions()

--- a/classes/autoptimizeVersionUpdatesHandler.php
+++ b/classes/autoptimizeVersionUpdatesHandler.php
@@ -46,10 +46,6 @@ class autoptimizeVersionUpdatesHandler
                 $this->upgrade_from_2_2();
                 $major_update = true;
                 // No break, intentionally, so all upgrades are ran during a single request...
-            case '2.3':
-                $this->upgrade_from_2_3();
-                $major_update = true;
-                // No break, intentionally, so all upgrades are ran during a single request...
         }
 
         if ( true === $major_update ) {
@@ -206,30 +202,5 @@ class autoptimizeVersionUpdatesHandler
             update_option( 'autoptimize_extra_settings', autoptimizeConfig::get_ao_extra_default_options() );
         }
         delete_option( 'autoptimize_css_nogooglefont' );
-    }
-
-    /**
-     * 2.4 adds (among other things) some new options which aren't strictly
-     * required to exist in the DB (since they default to true for now, and the
-     * UI showing them is not querying get_option() directly, but rather going
-     * throuh `autoptmizeConfig::get()` -- that makes sure the defaults are there).
-     * But I'm adding the code to add the values to the DB too just in case for now.
-     */
-    private function upgrade_from_2_3()
-    {
-        if ( ! is_multisite() ) {
-            update_option( 'autoptimize_css_aggregate', 'on' );
-            update_option( 'autoptimize_js_aggregate', 'on' );
-        } else {
-            global $wpdb;
-            $blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
-            $original_blog_id = get_current_blog_id();
-            foreach ( $blog_ids as $blog_id ) {
-                switch_to_blog( $blog_id );
-                update_option( 'autoptimize_css_aggregate', 'on' );
-                update_option( 'autoptimize_js_aggregate', 'on' );
-            }
-            switch_to_blog( $original_blog_id );
-        }
     }
 }

--- a/classes/autoptimizeVersionUpdatesHandler.php
+++ b/classes/autoptimizeVersionUpdatesHandler.php
@@ -46,6 +46,10 @@ class autoptimizeVersionUpdatesHandler
                 $this->upgrade_from_2_2();
                 $major_update = true;
                 // No break, intentionally, so all upgrades are ran during a single request...
+            case '2.3':
+                $this->upgrade_from_2_3();
+                $major_update = true;
+                // No break, intentionally, so all upgrades are ran during a single request...
         }
 
         if ( true === $major_update ) {
@@ -202,5 +206,30 @@ class autoptimizeVersionUpdatesHandler
             update_option( 'autoptimize_extra_settings', autoptimizeConfig::get_ao_extra_default_options() );
         }
         delete_option( 'autoptimize_css_nogooglefont' );
+    }
+
+    /**
+     * 2.4 adds (among other things) some new options which aren't strictly
+     * required to exist in the DB (since they default to true for now, and the
+     * UI showing them is not querying get_option() directly, but rather going
+     * throuh `autoptmizeConfig::get()` -- that makes sure the defaults are there).
+     * But I'm adding the code to add the values to the DB too just in case for now.
+     */
+    private function upgrade_from_2_3()
+    {
+        if ( ! is_multisite() ) {
+            update_option( 'autoptimize_css_aggregate', 'on' );
+            update_option( 'autoptimize_js_aggregate', 'on' );
+        } else {
+            global $wpdb;
+            $blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+            $original_blog_id = get_current_blog_id();
+            foreach ( $blog_ids as $blog_id ) {
+                switch_to_blog( $blog_id );
+                update_option( 'autoptimize_css_aggregate', 'on' );
+                update_option( 'autoptimize_js_aggregate', 'on' );
+            }
+            switch_to_blog( $original_blog_id );
+        }
     }
 }

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -1566,45 +1566,95 @@ HTML;
         remove_all_filters( 'autoptimize_filter_css_defer_inline' );
     }
 
-    public function test_js_aggregation_setting_and_dontaggregate_filter()
+    public function test_js_aggregation_decision_and_dontaggregate_filter()
     {
         $opts = $this->getAoScriptsDefaultOptions();
 
-        // Aggregating by default
+        // Aggregating: true by default
         $scripts = new autoptimizeScripts('');
         $scripts->read($opts);
         $this->assertTrue($scripts->aggregating());
 
-        // Not aggregating when option turns it off.
+        // Aggregating: option=true (dontaggregate=false by default).
+        $opts['aggregate'] = true;
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertTrue($scripts->aggregating());
+
+        // Aggregating: option=true, dontaggregate=false explicit.
+        add_filter( 'autoptimize_filter_js_dontaggregate', '__return_false' );
+        $opts['aggregate'] = true;
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertTrue($scripts->aggregating());
+        remove_all_filters( 'autoptimize_filter_js_dontaggregate' );
+
+        // Not aggregating: option=true, dontaggregate=true.
+        add_filter( 'autoptimize_filter_js_dontaggregate', '__return_true' );
+        $opts['aggregate'] = true;
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertFalse($scripts->aggregating());
+        remove_all_filters( 'autoptimize_filter_js_dontaggregate' );
+
+        // Not aggregating: option=false, dontaggregate=false.
+        add_filter( 'autoptimize_filter_js_dontaggregate', '__return_false' );
         $opts['aggregate'] = false;
         $scripts = new autoptimizeScripts('');
         $scripts->read($opts);
         $this->assertFalse($scripts->aggregating());
+        remove_all_filters( 'autoptimize_filter_js_dontaggregate' );
 
-        // Not aggregating when filter says so.
+        // Not aggregating: option=false, dontaggregate=true.
         add_filter( 'autoptimize_filter_js_dontaggregate', '__return_true' );
+        $opts['aggregate'] = false;
         $scripts = new autoptimizeScripts('');
         $scripts->read($opts);
         $this->assertFalse($scripts->aggregating());
         remove_all_filters( 'autoptimize_filter_js_dontaggregate' );
     }
 
-    public function test_css_aggregation_setting_and_dontaggregate_filter()
+    public function test_css_aggregation_decision_and_dontaggregate_filter()
     {
         $opts = $this->getAoStylesDefaultOptions();
 
-        // Aggregating by default
+        // Aggregating: true by default
         $styles = new autoptimizeStyles('');
         $this->assertTrue($styles->aggregating());
 
-        // Not aggregating when option turns
+        // Aggregating: option=true (dontaggregate=false by default).
+        $opts['aggregate'] = true;
+        $styles = new autoptimizeStyles('');
+        $styles->read($opts);
+        $this->assertTrue($styles->aggregating());
+
+        // Aggregating: option=true, dontaggregate=false explicit.
+        add_filter( 'autoptimize_filter_css_dontaggregate', '__return_false' );
+        $opts['aggregate'] = true;
+        $styles = new autoptimizeStyles('');
+        $styles->read($opts);
+        $this->assertTrue($styles->aggregating());
+        remove_all_filters( 'autoptimize_filter_css_dontaggregate' );
+
+        // Not aggregating: option=true, dontaggregate=true.
+        add_filter( 'autoptimize_filter_css_dontaggregate', '__return_true' );
+        $opts['aggregate'] = true;
+        $styles = new autoptimizeStyles('');
+        $styles->read($opts);
+        $this->assertFalse($styles->aggregating());
+        remove_all_filters( 'autoptimize_filter_css_dontaggregate' );
+
+        // Not aggregating: option=false, dontaggregate=false.
+        add_filter( 'autoptimize_filter_css_dontaggregate', '__return_false' );
         $opts['aggregate'] = false;
         $styles = new autoptimizeStyles('');
         $styles->read($opts);
         $this->assertFalse($styles->aggregating());
+        remove_all_filters( 'autoptimize_filter_css_dontaggregate' );
 
-        // Not aggregating when filter says so.
+        // Not aggregating: option=false, dontaggregate=true.
         add_filter( 'autoptimize_filter_css_dontaggregate', '__return_true' );
+        $opts['aggregate'] = false;
         $styles = new autoptimizeStyles('');
         $styles->read($opts);
         $this->assertFalse($styles->aggregating());

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -1565,4 +1565,49 @@ HTML;
         remove_all_filters( 'autoptimize_filter_css_defer' );
         remove_all_filters( 'autoptimize_filter_css_defer_inline' );
     }
+
+    public function test_js_aggregation_setting_and_dontaggregate_filter()
+    {
+        $opts = $this->getAoScriptsDefaultOptions();
+
+        // Aggregating by default
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertTrue($scripts->aggregating());
+
+        // Not aggregating when option turns it off.
+        $opts['aggregate'] = false;
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertFalse($scripts->aggregating());
+
+        // Not aggregating when filter says so.
+        add_filter( 'autoptimize_filter_js_dontaggregate', '__return_true' );
+        $scripts = new autoptimizeScripts('');
+        $scripts->read($opts);
+        $this->assertFalse($scripts->aggregating());
+        remove_all_filters( 'autoptimize_filter_js_dontaggregate' );
+    }
+
+    public function test_css_aggregation_setting_and_dontaggregate_filter()
+    {
+        $opts = $this->getAoStylesDefaultOptions();
+
+        // Aggregating by default
+        $styles = new autoptimizeStyles('');
+        $this->assertTrue($styles->aggregating());
+
+        // Not aggregating when option turns
+        $opts['aggregate'] = false;
+        $styles = new autoptimizeStyles('');
+        $styles->read($opts);
+        $this->assertFalse($styles->aggregating());
+
+        // Not aggregating when filter says so.
+        add_filter( 'autoptimize_filter_css_dontaggregate', '__return_true' );
+        $styles = new autoptimizeStyles('');
+        $styles->read($opts);
+        $this->assertFalse($styles->aggregating());
+        remove_all_filters( 'autoptimize_filter_css_dontaggregate' );
+    }
 }


### PR DESCRIPTION
Turned on by default (as was the case earlier), but can be turned off.
When turned off, css/js-files remain in place, but are still minified by AO.
Those trying things out with HTTP/2 might find this interesting to test.